### PR TITLE
Sign in with redirect instead of popup

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -20,7 +20,7 @@ const googleProvider = new firebase.auth.GoogleAuthProvider();
 
 const signInWithGoogle = async () => {
   try {
-    const res = await auth.signInWithPopup(googleProvider);
+    const res = await auth.signInWithRedirect(googleProvider);
     const user = res.user;
     const query = await db
       .collection("users")


### PR DESCRIPTION
When using Sign in with Google, use redirect instead of popup